### PR TITLE
Explicitly set state_class for statistics entities.

### DIFF
--- a/weather_forecast.yaml
+++ b/weather_forecast.yaml
@@ -451,12 +451,14 @@ template:
       - name: Local forecast Pressure
         unit_of_measurement: "hPa"
         device_class: 'atmospheric_pressure'
+        state_class: 'measurement'
         availability: "{{ states.sensor.local_forecast.attributes.p0 | is_number }}"
         state: >
           {{ states.sensor.local_forecast.attributes.p0|float(states.sensor.local_forecast_pressure.state) }}
       - name: Local forecast temperature
         unit_of_measurement: "°C"
         device_class: 'temperature'
+        state_class: 'measurement'
         availability: "{{ states.sensor.local_forecast.attributes.temperature | is_number }}"
         state: >
           {{ states.sensor.local_forecast.attributes.temperature|float(states.sensor.local_forecast_temperature.state) }}


### PR DESCRIPTION
In prior versions, both sensor.local_forecast_pressure and sensor.local_forecast_temperature would cause statistics engine errors (reported in Developer Tools -> Statistics). With the state_class of both set to 'measurement', these errors no longer occur.